### PR TITLE
Fix issue-3: don't call 'JavaModel.flushExternalFileCache'

### DIFF
--- a/sources/net.sf.j2s.core/src/net/sf/j2s/core/builder/JavaBuilder.java
+++ b/sources/net.sf.j2s.core/src/net/sf/j2s/core/builder/JavaBuilder.java
@@ -614,15 +614,6 @@ private int initializeBuilder(int kind, boolean forBuild) throws CoreException {
 		// Flush the existing external files cache if this is the beginning of a build cycle
 		String projectName = this.currentProject.getName();
 		if (builtProjects == null || builtProjects.contains(projectName)) {
-			try {
-				Method method = JavaModel.class.getMethod("flushExternalFileCache", new Class[] { Void.class });
-				if (method != null) {
-					method.invoke(JavaModel.class, new Object[0]);
-				}
-			} catch (Throwable e) {
-				e.printStackTrace();
-			}
-			//JavaModel.flushExternalFileCache();
 			builtProjects = new ArrayList();
 		}
 		builtProjects.add(projectName);


### PR DESCRIPTION
In the original Eclipse JavaBuilder class
(in org.eclipse.jdt.internal.core.builder) the call to
'JavaModel.flushExternalFileCache()' was removed, but not the copy of
that class in 'net.sf.j2s.core.builder'.